### PR TITLE
Fixed 'undefined local variable or method ' error

### DIFF
--- a/lib/ecs_helper/command/build_and_push.rb
+++ b/lib/ecs_helper/command/build_and_push.rb
@@ -93,6 +93,14 @@ class ECSHelper::Command::BuildAndPush < ECSHelper::Command::Base
     "#{repository}:#{helper.version}"
   end
 
+  def project
+    helper.project
+  end
+
+  def application
+    helper.application
+  end
+
   def repository
     @repository ||= begin
       all = client.private_repositories

--- a/test/support/ecs_helper_support.rb
+++ b/test/support/ecs_helper_support.rb
@@ -28,8 +28,4 @@ module ECSHelperSupport
     yield(new_setup)
     ARGV.replace prev
   end
-
-  def stub_terrapin
-    Terrapin::CommandLine.any_instance.stubs(:run).returns(true)
-  end
 end


### PR DESCRIPTION
In case if there's more than one target repository (in my particular case there are multiple ECR repos for different sub-projects with `nginx` in their name) and we go to this section:

```ruby
      exact = with_name.select { |r| r.repository_arn.include?(project) && r.repository_arn.include?(application) }
      return exact[0].repository_uri if exact.length === 1
```

`project` and `application` variables are not defined which throws an exception.