### PR TITLE
[WIP] Converted deploy timeout value fetched from options to  integer number

### DIFF
--- a/lib/ecs_helper/command/deploy.rb
+++ b/lib/ecs_helper/command/deploy.rb
@@ -70,7 +70,7 @@ class ECSHelper::Command::Deploy < ECSHelper::Command::Base
   end
 
   def timeout
-    options[:timeout] || DEFAULT_TIMEOUT
+    (options[:timeout] || DEFAULT_TIMEOUT).to_i
   end
 
   def service


### PR DESCRIPTION
If you try to use `ecs_helper deploy` with the timeout option you will get an error.

```
$ ecs_helper deploy -t 600
/usr/lib/ruby/gems/2.7.0/gems/ecs_helper-0.0.28/lib/ecs_helper/command/deploy.rb:49:in `>': comparison of Integer with String failed (ArgumentError)
	from /usr/lib/ruby/gems/2.7.0/gems/ecs_helper-0.0.28/lib/ecs_helper/command/deploy.rb:49:in `wait_for_deployment'
	from /usr/lib/ruby/gems/2.7.0/gems/ecs_helper-0.0.28/lib/ecs_helper/command/deploy.rb:39:in `run'
	from /usr/lib/ruby/gems/2.7.0/gems/ecs_helper-0.0.28/lib/ecs_helper/command.rb:46:in `run'
	from /usr/lib/ruby/2.7.0/forwardable.rb:235:in `run'
	from /usr/lib/ruby/gems/2.7.0/gems/ecs_helper-0.0.28/bin/ecs_helper:8:in `<top (required)>'
	from /usr/bin/ecs_helper:23:in `load'
	from /usr/bin/ecs_helper:23:in `<main>'
```

TODO: Need to add tests for `deploy` command.